### PR TITLE
Validator Update Command

### DIFF
--- a/pkg/agave/assets.go
+++ b/pkg/agave/assets.go
@@ -6,3 +6,6 @@ import (
 
 //go:embed assets/install.sh
 var InstallScript string
+
+//go:embed assets/update.sh
+var UpdateScript string

--- a/pkg/agave/assets/update.sh
+++ b/pkg/agave/assets/update.sh
@@ -1,0 +1,11 @@
+# -*- mode: shell-script -*-
+# shellcheck shell=bash
+
+step::00::update-run-validator() {
+  cat <<EOF | $SUDO tee /home/sol/run-validator >/dev/null
+#!/usr/bin/env bash
+exec agave-validator $VALIDATOR_FLAGS
+EOF
+
+  $SUDO systemctl restart svmkit-agave-validator.service
+}

--- a/pkg/agave/validator.go
+++ b/pkg/agave/validator.go
@@ -38,6 +38,21 @@ func (cmd *InstallCommand) Script() string {
 	return InstallScript
 }
 
+type UpdateCommand struct {
+	runner.Command
+	Flags Flags
+}
+
+func (cmd *UpdateCommand) Env() map[string]string {
+	return map[string]string{
+		"VALIDATOR_FLAGS": strings.Join(cmd.Flags.toArgs(), " "),
+	}
+}
+
+func (cmd *UpdateCommand) Script() string {
+	return UpdateScript
+}
+
 type ValidatorPaths struct {
 	Accounts string `pulumi:"accounts"`
 	Ledger   string `pulumi:"ledger"`
@@ -54,6 +69,12 @@ func (agave *Agave) Install() runner.Command {
 	return &InstallCommand{
 		Flags:    agave.Flags,
 		KeyPairs: agave.KeyPairs,
+	}
+}
+
+func (agave *Agave) Update() runner.Command {
+	return &UpdateCommand{
+		Flags: agave.Flags,
 	}
 }
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -9,6 +9,8 @@ type KeyPairs map[string]string
 type Client interface {
 	// Install returns a Command to install the blockchain validator.
 	Install() runner.Command
+	// Update returns a Command to update the blockchain validator.
+	Update() runner.Command
 }
 
 // ClientFlags is an interface for client flags for the validator.


### PR DESCRIPTION
## Changes
- Add update to validator interface
- Implement update for agave which switches flags and restarts service


```
     Type                       Name                                     Plan        Info
     pulumi:pulumi:Stack        provider-svm-native-aws-agave-validator
 +-  └─ svmkit:validator:Agave  validator                                replace     [diff: ]

Resources:
    +-1 to replace
    7 unchanged

Do you want to perform this update? yes
Updating (aws-agave-validator)

     Type                       Name                                     Status
     pulumi:pulumi:Stack        provider-svm-native-aws-agave-validator
 +-  └─ svmkit:validator:Agave  validator                                replaced (0.25s)

Outputs:
    PUBLIC_DNS_NAME: "..."
    SSH_PRIVATE_KEY: [secret]

Resources:
    +-1 replaced
    7 unchanged

Duration: 26s
```