### PR TITLE
Install Agave Version

### DIFF
--- a/pkg/agave/assets/install.sh
+++ b/pkg/agave/assets/install.sh
@@ -66,7 +66,11 @@ EOF
 }
 
 step::70::install-validator() {
-  $APT install zuma-agave-validator zuma-solana-cli
+  if [[ -v VALIDATOR_VERSION ]]; then
+    $APT install "zuma-agave-validator=$VALIDATOR_VERSION" "zuma-solana-cli=$VALIDATOR_VERSION"
+  else
+    $APT install "zuma-agave-validator" "zuma-solana-cli"
+  fi
 }
 
 step::80::setup-validator-startup() {

--- a/pkg/agave/validator.go
+++ b/pkg/agave/validator.go
@@ -24,14 +24,21 @@ type InstallCommand struct {
 	runner.Command
 	Flags    Flags
 	KeyPairs KeyPairs
+	Version  validator.Version
 }
 
 func (cmd *InstallCommand) Env() map[string]string {
-	return map[string]string{
+	env := map[string]string{
 		"VALIDATOR_FLAGS":      strings.Join(cmd.Flags.toArgs(), " "),
 		"IDENTITY_KEYPAIR":     cmd.KeyPairs.Identity,
 		"VOTE_ACCOUNT_KEYPAIR": cmd.KeyPairs.VoteAccount,
 	}
+
+	if cmd.Version != nil {
+		env["VALIDATOR_VERSION"] = *cmd.Version
+	}
+
+	return env
 }
 
 func (cmd *InstallCommand) Script() string {
@@ -46,14 +53,16 @@ type ValidatorPaths struct {
 
 type Agave struct {
 	validator.Client
-	KeyPairs KeyPairs
-	Flags    Flags
+	Version  validator.Version `pulumi:"version,optional"`
+	KeyPairs KeyPairs          `pulumi:"keyPairs" provider:"secret"`
+	Flags    Flags             `pulumi:"flags"`
 }
 
 func (agave *Agave) Install() runner.Command {
 	return &InstallCommand{
 		Flags:    agave.Flags,
 		KeyPairs: agave.KeyPairs,
+		Version:  agave.Version,
 	}
 }
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -5,6 +5,9 @@ import "github.com/abklabs/svmkit/pkg/runner"
 // KeyPairs is a map of key pairs for the blockchain validator.
 type KeyPairs map[string]string
 
+// Version is the semantic version (semver) of the blockchain validator apt package.
+type Version *string
+
 // Client is an interface for managing the blockchain validator.
 type Client interface {
 	// Install returns a Command to install the blockchain validator.


### PR DESCRIPTION
## Changes
- Set what version of the validator to run. 
- Install same version for the solana cli.

## ⚠️ Warning 
The version must be availabe in the abklabs apt repository.