### PR TITLE
Add tachyon agave variant

### DIFF
--- a/build/solana-build
+++ b/build/solana-build
@@ -191,4 +191,4 @@ build-ref svmkit-mantis-validator mantis/mantis/diet-validator-rpc solana-valida
 
 build-ref svmkit-xen-validator xen/dyn_fees_v1 solana-validator
 
-build-ref svmkit-xen-validator tachyon/dyn_fees_v2 solana-validator
+build-ref svmkit-tachyon-validator tachyon/dyn_fees_v2 tachyon-validator

--- a/pkg/agave/variant.go
+++ b/pkg/agave/variant.go
@@ -16,6 +16,7 @@ const (
 	VariantPyth        Variant = "pyth"
 	VariantMantis      Variant = "mantis"
 	VariantXen         Variant = "xen"
+	VariantTachyon     Variant = "tachyon"
 )
 
 func (Variant) Values() []infer.EnumValue[Variant] {
@@ -55,12 +56,17 @@ func (Variant) Values() []infer.EnumValue[Variant] {
 			Value:       VariantXen,
 			Description: "The Xen validator",
 		},
+		{
+			Name:        string(VariantTachyon),
+			Value:       VariantTachyon,
+			Description: "The Tachyon validator",
+		},
 	}
 }
 
 func (v Variant) Check() error {
 	switch v {
-	case VariantSolana, VariantAgave, VariantPowerledger, VariantJito, VariantPyth, VariantMantis, VariantXen:
+	case VariantSolana, VariantAgave, VariantPowerledger, VariantJito, VariantPyth, VariantMantis, VariantXen, VariantTachyon:
 	default:
 		return fmt.Errorf("unknown validator variant '%s'!", v)
 	}
@@ -74,6 +80,8 @@ func (v Variant) ProcessName() string {
 		return "agave-validator"
 	case VariantMantis, VariantPowerledger, VariantPyth, VariantSolana, VariantXen:
 		return "solana-validator"
+	case VariantTachyon:
+		return "tachyon-validator"
 	default:
 		// XXX - Eh, not my favorite, but you should have checked!
 		return ""


### PR DESCRIPTION
## Changes
- New variant on agave for `tachyon` the validator client for the X1 blockchain
- Fix build to ship tachyon as separate validator package `svmkit-tachyon-validator`