### PR TITLE
Rename SlotPerEpoch -> SlotsPerEpoch (breaking)

### DIFF
--- a/pkg/solana/genesis/genesis.go
+++ b/pkg/solana/genesis/genesis.go
@@ -19,7 +19,7 @@ const (
 	defaultTargetLamportsPerSignature = 0
 	defaultInflation                  = "none"
 	defaultLamportsPerByteYear        = 1
-	defaultSlotPerEpoch               = 150
+	defaultSlotsPerEpoch              = 150
 )
 
 type CreateCommand struct {
@@ -155,7 +155,7 @@ type GenesisFlags struct {
 	MaxGenesisArchiveUnpackedSize   *int      `pulumi:"maxGenesisArchiveUnpackedSize,optional"`
 	RentBurnPercentage              *int      `pulumi:"rentBurnPercentage,optional"`
 	RentExemptionThreshold          *int      `pulumi:"rentExemptionThreshold,optional"`
-	SlotPerEpoch                    *int      `pulumi:"slotPerEpoch,optional"`
+	SlotsPerEpoch                   *int      `pulumi:"slotsPerEpoch,optional"`
 	TargetLamportsPerSignature      *int      `pulumi:"targetLamportsPerSignature,optional"`
 	TargetSignaturesPerSlot         *int      `pulumi:"targetSignaturesPerSlot,optional"`
 	TargetTickDuration              *int      `pulumi:"targetTickDuration,optional"`
@@ -221,10 +221,10 @@ func (f GenesisFlags) Args() []string {
 	b.AppendIntP("rent-burn-percentage", f.RentBurnPercentage)
 	b.AppendIntP("rent-exemption-threshold", f.RentExemptionThreshold)
 
-	if f.SlotPerEpoch != nil {
-		b.AppendIntP("slots-per-epoch", f.SlotPerEpoch)
+	if f.SlotsPerEpoch != nil {
+		b.AppendIntP("slots-per-epoch", f.SlotsPerEpoch)
 	} else {
-		value := defaultSlotPerEpoch
+		value := defaultSlotsPerEpoch
 		b.AppendIntP("slots-per-epoch", &value)
 	}
 

--- a/pkg/solana/genesis/genesis_test.go
+++ b/pkg/solana/genesis/genesis_test.go
@@ -27,7 +27,7 @@ func TestGenesisFlags(t *testing.T) {
 	maxGenesisArchiveUnpackedSize := 1073741824
 	rentBurnPercentage := 5
 	rentExemptionThreshold := 10
-	slotPerEpoch := 432000
+	slotsPerEpoch := 432000
 	targetLamportsPerSignature := 42
 	targetSignaturesPerSlot := 250000
 	targetTickDuration := 400
@@ -57,7 +57,7 @@ func TestGenesisFlags(t *testing.T) {
 		MaxGenesisArchiveUnpackedSize:   &maxGenesisArchiveUnpackedSize,
 		RentBurnPercentage:              &rentBurnPercentage,
 		RentExemptionThreshold:          &rentExemptionThreshold,
-		SlotPerEpoch:                    &slotPerEpoch,
+		SlotsPerEpoch:                   &slotsPerEpoch,
 		TargetLamportsPerSignature:      &targetLamportsPerSignature,
 		TargetSignaturesPerSlot:         &targetSignaturesPerSlot,
 		TargetTickDuration:              &targetTickDuration,


### PR DESCRIPTION
The struct field was renamed to align with --slots-per-epoch in the solana-genesis CLI, hence this is a breaking change. All other struct field names were audited to match the CLI flags.