### PR TITLE
Don't return an SSH EOF as an error

### DIFF
--- a/pkg/runner/deployer/ssh.go
+++ b/pkg/runner/deployer/ssh.go
@@ -94,7 +94,9 @@ func (p *SSH) Run(cmdSegs []string, handler DeployerHandler) (err error) {
 	}
 
 	defer func() {
-		err = errors.Join(err, execSession.Close())
+		if closeErr := execSession.Close(); closeErr != io.EOF {
+			err = errors.Join(closeErr)
+		}
 	}()
 
 	stdoutPipe, err := execSession.StdoutPipe()


### PR DESCRIPTION
There can be more than a handful of reasons why we would get an EOF when we try to close.  So just filter this out.