### PR TITLE
KIT-402 - Correct config parameter ordering in fdctl systemd service

### DIFF
--- a/pkg/firedancer/assets/svmkit-fd-setup.service
+++ b/pkg/firedancer/assets/svmkit-fd-setup.service
@@ -7,7 +7,7 @@ After=network.target
 Type=exec
 User=root
 Group=root
-ExecStart=/opt/frankendancer/bin/fdctl --config /home/sol/config.toml configure init all
+ExecStart=/opt/frankendancer/bin/fdctl configure init all --config /home/sol/config.toml 
 RemainAfterExit=true
 Type=oneshot
 

--- a/pkg/firedancer/assets/svmkit-fd.service
+++ b/pkg/firedancer/assets/svmkit-fd.service
@@ -7,7 +7,7 @@ Requires=svmkit-fd-setup.service
 Type=exec
 User=root
 Group=root
-ExecStart=/opt/frankendancer/bin/fdctl --config /home/sol/config.toml run
+ExecStart=/opt/frankendancer/bin/fdctl run --config /home/sol/config.toml
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
- Fixes systemd service startup failure. The fdctl command expects flag ordering as `fdctl subcommand --config ` not `fdctl --config subcommand`.