### PR TITLE
Switch to using opsh for build scripts

### DIFF
--- a/build/firedancer-build
+++ b/build/firedancer-build
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
+#!/usr/bin/env opsh
 
 if [[ $# -ne 1 ]]; then
 	echo "$0 tag"

--- a/build/solana-build
+++ b/build/solana-build
@@ -1,48 +1,8 @@
-#!/usr/bin/env bash
+#!/usr/bin/env opsh
 
-set -euo pipefail
+lib::import git
 
-log::generic() {
-    local level
-    level=$1
-    shift
-
-    printf "%s\t%s\n" "$level" "$*"
-}
-
-log::info() {
-    log::generic INFO "$@"
-}
-
-log::fatal() {
-    log::generic FATAL "$@"
-    exit 1
-}
-
-lookup-remote-tag() {
-    local remote tag tagfile tagcount
-    remote=$1
-    shift
-    tag=$1
-    shift
-
-    tagfile=$(mktemp)
-
-    git ls-remote --tags "$remote" "$tag" >"$tagfile"
-
-    tagcount=$(wc -l <"$tagfile")
-
-    if [[ $tagcount -lt 1 ]]; then
-        log::fatal "no tags found on $remote for $tag!"
-    fi
-
-    if [[ $tagcount -gt 1 ]]; then
-        log::fatal "found more than one tag matching $tag on $remote.  cowardly giving up!"
-    fi
-
-    awk '{ print $1;}' <"$tagfile"
-    rm "$tagfile"
-}
+opsh::version::require v0.7.0
 
 fetch-remote() {
     local remote
@@ -97,13 +57,13 @@ done
 build-ref svmkit-solana solana-labs/master solana-validator
 
 for tag in v2.1.13 v2.1.14 v2.1.15 v2.1.16 v2.1.21 v2.2.0 v2.2.1; do
-    build-ref svmkit-agave "$(lookup-remote-tag anza-xyz $tag)" agave-validator anza-build-extra
+    build-ref svmkit-agave "$(git::tag::lookup::remote anza-xyz $tag)" agave-validator anza-build-extra
 done
 
 build-ref svmkit-powerledger PowerLedger/upgrade_to_v1.16.28 solana-validator
 
 for tag in v2.0.18-jito v2.0.19-jito v2.0.21-jito v2.0.22-jito v2.1.7-jito v2.1.11-jito v2.1.13-jito v2.1.16-jito v2.1.21-jito; do
-    build-ref svmkit-jito "$(lookup-remote-tag jito-foundation $tag)" agave-validator
+    build-ref svmkit-jito "$(git::tag::lookup::remote jito-foundation $tag)" agave-validator
 done
 
 build-ref svmkit-pyth pyth-network/pyth-v1.14.17 solana-validator build-with-other-clang

--- a/build/yellowstone-grpc-build
+++ b/build/yellowstone-grpc-build
@@ -1,48 +1,8 @@
-#!/usr/bin/env bash
+#!/usr/bin/env opsh
 
-set -euo pipefail
+lib::import git
 
-log::generic() {
-    local level
-    level=$1
-    shift
-
-    printf "%s\t%s\n" "$level" "$*"
-}
-
-log::info() {
-    log::generic INFO "$@"
-}
-
-log::fatal() {
-    log::generic FATAL "$@"
-    exit 1
-}
-
-lookup-remote-tag() {
-    local remote tag tagfile tagcount
-    remote=$1
-    shift
-    tag=$1
-    shift
-
-    tagfile=$(mktemp)
-
-    git ls-remote --tags "$remote" "$tag" >"$tagfile"
-
-    tagcount=$(wc -l <"$tagfile")
-
-    if [[ $tagcount -lt 1 ]]; then
-        log::fatal "no tags found on $remote for $tag!"
-    fi
-
-    if [[ $tagcount -gt 1 ]]; then
-        log::fatal "found more than one tag matching $tag on $remote.  cowardly giving up!"
-    fi
-
-    awk '{ print $1;}' <"$tagfile"
-    rm "$tagfile"
-}
+opsh::version::require v0.7.0
 
 fetch-remote() {
     local remote
@@ -75,7 +35,7 @@ build-grpc() {
 fetch-remote yellowstone-grpc
 
 for tag in v5.0.1+solana.2.1.13 v5.0.1+solana.2.1.14 v5.0.1+solana.2.1.15 v5.0.1+solana.2.1.16 v6.0.0+solana.2.2.1; do
-    commit=$(lookup-remote-tag yellowstone-grpc "$tag")
+    commit=$(git::tag::lookup::remote yellowstone-grpc "$tag")
     agave_ver=$(echo "$tag" | sed 's|.*solana\.||')
     build_dir="../build/$commit"
     build-grpc "$agave_ver" "$commit" "$build_dir"


### PR DESCRIPTION
This cuts down on the boilerplate, and lets us just depend on functionality provided by opsh by default.