### PR TITLE
Kit 427 add a firewall component to svmkit

### DIFF
--- a/pkg/agave/assets/install.sh.tmpl
+++ b/pkg/agave/assets/install.sh.tmpl
@@ -35,24 +35,6 @@ step::35::copy-plugin-config() {
     fi
 }
 
-step::40::configure-firewall() {
-    svmkit::sudo ufw allow 53
-    svmkit::sudo ufw allow ssh
-    svmkit::sudo ufw allow 8000:8020/tcp
-    svmkit::sudo ufw allow 8000:8020/udp
-    # TODO: Only open for RPC nodes
-    svmkit::sudo ufw allow 8899/tcp
-    svmkit::sudo ufw allow 8899/udp
-    svmkit::sudo ufw allow 8900/tcp
-
-    if [[ -v YELLOWSTONE_GRPC_PORT ]] ; then
-      svmkit::sudo ufw allow "${YELLOWSTONE_GRPC_PORT}"/tcp
-      svmkit::sudo ufw allow "${YELLOWSTONE_GRPC_PORT}"/udp
-    fi
-
-    svmkit::sudo ufw --force enable
-}
-
 step::60::setup-solana-cli() {
     [[ -v SOLANA_CLI_CONFIG_FLAGS ]] || return 0
 

--- a/pkg/firewall/assets.go
+++ b/pkg/firewall/assets.go
@@ -1,0 +1,11 @@
+package firewall
+
+import (
+	"embed"
+	"text/template"
+)
+
+//go:embed assets
+var assets embed.FS
+
+var firewallScriptTmpl = template.Must(template.ParseFS(assets, "assets/firewall.sh.tmpl"))

--- a/pkg/firewall/assets/firewall.sh.tmpl
+++ b/pkg/firewall/assets/firewall.sh.tmpl
@@ -1,0 +1,21 @@
+# -*- mode: shell-script -*-
+# shellcheck shell=bash
+
+step::00::wait-for-a-stable-environment() {
+    cloud-init::wait-for-stable-environment
+}
+
+step::10::install-packages() {
+    svmkit::apt::update
+    svmkit::apt::get --allow-downgrades install "${PACKAGE_LIST[@]}"
+}
+
+step::40::configure-firewall() {
+    svmkit::sudo ufw default deny incoming  # the default - deny all
+    {{- range .Params.AllowPorts }}
+    svmkit::sudo ufw allow {{ . }}
+    {{- end }}
+
+    svmkit::sudo ufw --force enable
+}
+

--- a/pkg/firewall/defaults.go
+++ b/pkg/firewall/defaults.go
@@ -1,0 +1,86 @@
+package firewall
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+//go:embed defaults/generic.defaults.toml
+var defaultFirewallGenericToml []byte
+
+type FirewallVariant string
+
+const (
+	FirewallVariantGeneric FirewallVariant = "generic"
+)
+
+func (FirewallVariant) Values() []infer.EnumValue[FirewallVariant] {
+	return []infer.EnumValue[FirewallVariant]{
+		{
+			Name:        string(FirewallVariantGeneric),
+			Value:       FirewallVariantGeneric,
+			Description: "The generic firewall",
+		},
+	}
+}
+
+func (v FirewallVariant) Check() error {
+	switch v {
+	case FirewallVariantGeneric:
+		return nil
+	default:
+		return fmt.Errorf("unknown firewall variant '%s'", v)
+	}
+}
+
+func NewDefaultFirewall(variant ...FirewallVariant) (*Firewall, error) {
+	var v FirewallVariant
+	if len(variant) == 0 || variant[0] == "" {
+		v = FirewallVariantGeneric
+	} else {
+		v = variant[0]
+	}
+
+	if err := v.Check(); err != nil {
+		return nil, err
+	}
+
+	var content []byte
+	switch v {
+	default:
+		content = defaultFirewallGenericToml
+	}
+
+	var t Firewall
+	if err := toml.Unmarshal(content, &t); err != nil {
+		return nil, err
+	}
+
+	return &t, nil
+}
+
+var firewallParams = map[FirewallVariant]func() (*FirewallParams, error){
+	FirewallVariantGeneric: func() (*FirewallParams, error) {
+		t, err := NewDefaultFirewall(FirewallVariantGeneric)
+		if err != nil {
+			return nil, err
+		}
+		return &t.Params, nil
+	},
+}
+
+func GetDefaultFirewallParams(variant ...FirewallVariant) (*FirewallParams, error) {
+	if len(variant) == 0 || variant[0] == "" {
+		variant = append(variant, FirewallVariantGeneric)
+	}
+
+	fn, ok := firewallParams[variant[0]]
+	if !ok {
+		return nil, fmt.Errorf("unknown firewall variant '%s'", variant[0])
+	}
+
+	return fn()
+}

--- a/pkg/firewall/defaults/generic.defaults.toml
+++ b/pkg/firewall/defaults/generic.defaults.toml
@@ -1,0 +1,12 @@
+# generic.defaults.toml
+
+[params]
+
+# List of ports and/or services to allow through the firewall.
+# If this is empty or omitted, all ports are denied (except those allowed by default ufw rules).
+allow_ports = []
+# Or it could be something like:
+# [
+#  "ssh",           # Allow SSH
+#  "53",            # Allow DNS (TCP+UDP)
+#]

--- a/pkg/firewall/defaults_test.go
+++ b/pkg/firewall/defaults_test.go
@@ -1,0 +1,16 @@
+package firewall
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Create a new default Firewall (update this call if it now expects different arguments)
+
+func TestNewDefaultFirewall(t *testing.T) {
+	firewall, err := NewDefaultFirewall()
+	require.NoError(t, err, "NewDefaultFirewall should not return an error")
+	require.NotNil(t, firewall, "NewDefaultFirewall should return a non-nil Firewall struct")
+
+}

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -1,0 +1,57 @@
+package firewall
+
+import (
+	"github.com/abklabs/svmkit/pkg/runner"
+	"github.com/abklabs/svmkit/pkg/runner/deb"
+
+	"dario.cat/mergo"
+)
+
+type FirewallCommand struct {
+	Firewall
+}
+
+func (cmd *FirewallCommand) Check() error {
+	cmd.SetConfigDefaults()
+
+	pkgGrp := deb.Package{}.MakePackageGroup("ufw")
+
+	if err := cmd.UpdatePackageGroup(pkgGrp); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *FirewallCommand) AddToPayload(p *runner.Payload) error {
+	if err := p.AddTemplate("steps.sh", firewallScriptTmpl, cmd); err != nil {
+		return err
+	}
+	if err := cmd.RunnerCommand.AddToPayload(p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type FirewallParams struct {
+	AllowPorts []string `pulumi:"allowPorts" toml:"allowPorts"`
+}
+
+type Firewall struct {
+	runner.RunnerCommand
+	Params FirewallParams `pulumi:"params" toml:"params"`
+}
+
+func (f *Firewall) Create() runner.Command {
+	return &FirewallCommand{
+		Firewall: *f,
+	}
+}
+
+func (t *Firewall) Merge(other *Firewall) error {
+	if other == nil {
+		return nil
+	}
+	return mergo.Merge(t, other, mergo.WithOverride)
+}

--- a/pkg/registry/component.go
+++ b/pkg/registry/component.go
@@ -12,6 +12,7 @@ import (
 	"github.com/abklabs/svmkit/pkg/solana/genesis"
 	"github.com/abklabs/svmkit/pkg/solana/watchtower"
 	"github.com/abklabs/svmkit/pkg/tuner"
+	"github.com/abklabs/svmkit/pkg/firewall"
 )
 
 type Component int
@@ -26,6 +27,7 @@ const (
 	ComponentStakeAccount
 	ComponentTransfer
 	ComponentTuner
+	ComponentFirewall
 	ComponentVoteAccount
 	ComponentWatchtower
 )
@@ -50,6 +52,8 @@ func (a Component) String() string {
 		return "transfer"
 	case ComponentTuner:
 		return "tuner"
+	case ComponentFirewall:
+		return "firewall"
 	case ComponentVoteAccount:
 		return "voteAccount"
 	case ComponentWatchtower:
@@ -182,6 +186,18 @@ var Components = []ComponentCommand{
 				ActionCreate,
 				func() runner.Command {
 					return (&tuner.Tuner{}).Create()
+				},
+			},
+		},
+	},
+	{
+		ComponentFirewall,
+		"Configure the SVMKit firewall.",
+		[]*ComponentOp{
+			{
+				ActionCreate,
+				func() runner.Command {
+					return (&firewall.Firewall{}).Create()
 				},
 			},
 		},


### PR DESCRIPTION
Add a simple firewall component to svmkit.  
Under the hood it just uses ufw.
By default, it will deny all inbound.